### PR TITLE
Fix error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var root = new Vue({
 
     ready: function() {
         // Explicit call
-        this.startPreloader();
+        this.load();
     },
 
     methods: {


### PR DESCRIPTION
Explicit call method is `load` instead of `startPreloader` in README